### PR TITLE
Don't terminate on unknown tape commands

### DIFF
--- a/src/tapemaster.c
+++ b/src/tapemaster.c
@@ -1021,7 +1021,8 @@ void tapemaster_clock_pulse(){
       default:
         logmsgf(LT_TAPEMASTER,0,"TM: Unknown Command 0x%X\n",TM_PB.Command);
         TM_Controller_State = 0;
-        ld_die_rq = 1;
+	// BV: no reason to DIE, for all those known but unimplemented commands
+	// ld_die_rq = 1;
       }
       break;
 


### PR DESCRIPTION
It is quite irritating when the whole emulator terminates because an unknown/unsupported tape command was issued, e.g. clicking "Unload" in the Backup tool.

Fixes issue #16 