### PR TITLE
Configurable video height

### DIFF
--- a/src/vcmem.c
+++ b/src/vcmem.c
@@ -52,7 +52,7 @@ void vcmem_init(int vn,int slot){
   vcS[vn].MemoryControl.MemCopy = 1;
   int x = 0;
   // Clobber A memory
-  while(x < 1024*128){
+  while(x < FB_SIZE){
     vcS[vn].AMemory[x] = 0;
     x++;
   }
@@ -408,7 +408,7 @@ void vcmem_clock_pulse(int vn){
 
 	// The scanline table is at 0x6000-0x7FFC
 	// Each entry is the offset of the start of that scanline.
-      case 0x6000 ... 0x7FFF:
+      case 0x6000 ... (0x6000+4*(SLT_SIZE)-1):
 	if(NUbus_Request == VM_READ){
 	  uint32_t Scanline = ((NUbus_Address.Addr-0x6000)>>2);
 	  // This is a mono framebuffer, and our resolution is 800 x 1024.
@@ -462,7 +462,7 @@ void vcmem_clock_pulse(int vn){
 	break;
 
 	// Framebuffer is at 0x20000-0x3FFFF
-      case 0x20000 ... 0x3FFFF:
+      case 0x20000 ... 0x20000+FB_SIZE-1:
 	if(NUbus_Request == VM_READ || NUbus_Request == VM_BYTE_READ){
 	  uint32_t FBAddr = NUbus_Address.Addr-0x20000;
 	  if(NUbus_Request == VM_READ){ // Read four bytes

--- a/src/vcmem.h
+++ b/src/vcmem.h
@@ -93,12 +93,16 @@ typedef union rSerialControlReg {
   } __attribute__((packed));
 } SerialControlReg;
 
+// Framebuffer and scanline table sizes
+#define FB_SIZE (1024*128)
+#define SLT_SIZE (0x800)
+
 // Card state
 struct vcmemState {
   // Memories
-  uint8_t AMemory[1024*128];
-  uint8_t BMemory[1024*128];
-  uint32_t SLT[0x800]; // Scanline Table
+  uint8_t AMemory[FB_SIZE];
+  uint8_t BMemory[FB_SIZE];
+  uint32_t SLT[SLT_SIZE]; // Scanline Table
   // Register storage
   FunctionReg Function;
   MemoryControlReg MemoryControl;


### PR DESCRIPTION
Support configuring the video height (up to 1024). To change the lispm view, use (TV:SET-CONSOLE-SIZE width height).
(Config parsing not yet for YAML.)

Solves issue #23 (up to 1024).