### PR TITLE
Makefile.am (lam_LDFLAGS): New variable.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,3 +6,5 @@ bin_PROGRAMS = lam lpart
 lam_SOURCES = 3com.c lambda_cpu.c mem.c sdu.c smd.c tapemaster.c kernel.c nubus.c sdu_hw.c syms.c vcmem.c 3com.h ld.h nubus.h sdu_hw.h syms.h vcmem.h lambda_cpu.h mem.h sdu.h smd.h tapemaster.h
 
 lpart_SOURCES = lpart.c
+
+lam_LDFLAGS = -lm


### PR DESCRIPTION
The file `src/kernel.c` uses `sin`; so we should also link against `libm`.  Otherwise one gets,

```
gcc -std=gnu99 -Wall -Wextra -Wno-packed-bitfield-compat -ggdb -Og -g -O2 -DXBEEP -DCONFIG_2X2 -D_REENTRANT -I/usr/include/SDL2 -DSDL2 -DSYSCONFDIR=/usr/local/etc -ggdb -Og  -o lam 3com.o lambda_cpu.o mem.o sdu.o smd.o tapemaster.o kernel.o nubus.o sdu_hw.o syms.o vcmem.o  -lSDL2
/usr/bin/ld: kernel.o: undefined reference to symbol 'sin@@GLIBC_2.2.5'
/usr/bin/ld: //lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```