### PR TITLE
Fix libm link order issue.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,4 +7,4 @@ lam_SOURCES = 3com.c lambda_cpu.c mem.c sdu.c smd.c tapemaster.c kernel.c nubus.
 
 lpart_SOURCES = lpart.c
 
-lam_LDFLAGS = -lm
+lam_LDADD = -lm


### PR DESCRIPTION
Fixes #36 by asking libm to appear later in the link line for `lam`.

Tested on Debian Slim and Ubuntu 20.04.