### PR TITLE
Support for Locally Administered Addresses for ethernet interfaces

### DIFF
--- a/doc/OLDCONF.md
+++ b/doc/OLDCONF.md
@@ -23,6 +23,8 @@
   LAN, so do not make it the same as the host! It is written in the
   canonical colon-separated hex format.
   The default is 00:02:9C:55:89:C6.
+  You can also specify LAA (case-insensitive) to generate a Locally Administered Address,
+  which is saved persistently per interface in the file $IFNAME.LAA.
 
   disk N FNAME
 

--- a/examples/lam.yml
+++ b/examples/lam.yml
@@ -94,6 +94,14 @@ network:
   interface: ldtap
   # The Lambda's MAC address
   address: 00:02:9C:55:89:C6
+  # Alternatively, to avoid collisions (and manual configuration)
+  # if you run more than one lam process on your network,
+  # you can specify LAA to generate a random
+  # Locally Administered Address, which is saved persistently
+  # in the file $interface.LAA.
+  # (This uses the interface name defined when parsing the address setting,
+  # so have the "interface:" before "address: LAA")
+  address: LAA
   # The Lambda's guest IP if you are using UTUN (otherwise undefined key)
   guest-ip: aaa.bbb.ccc.ddd
 

--- a/src/3com.c
+++ b/src/3com.c
@@ -991,18 +991,15 @@ int yaml_network_mapping_loop(yaml_parser_t *parser){
 	}
 #endif
 	if(strcmp(key,"address") == 0){
-	  int x = 0;
-	  char *tok;
-	  char *str = value;
-	  while(x < 6){
-	    long int val = 0;
-	    tok = strtok(str," :\t\r\n");
-	    if(str != NULL){ str = NULL; } // Clobber
-	    if(tok != NULL){
-	      val = strtol(tok,NULL,16);
-	    }
-	    ether_addr[x] = val;
-	    x++;
+	  if (strcasecmp(value,"laa") == 0) {
+	    make_locally_administered_address_for_interface(ether_iface, ether_addr);
+	  } else if (sscanf(value,"%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", 
+		     &ether_addr[0],&ether_addr[1],&ether_addr[2],&ether_addr[3],&ether_addr[4],&ether_addr[5]) 
+		     // try to parse an explicit address
+	      != 6) {
+	    // fail, so complain
+	    logmsgf(LT_3COM,0,"network address: could not parse value '%s'\n", value);
+	    return -1;
 	  }
 	  logmsgf(LT_3COM,0,"Using 3Com Ethernet address %.2X:%.2X:%.2X:%.2X:%.2X:%.2X\n",
 		 ether_addr[0],ether_addr[1],ether_addr[2],ether_addr[3],ether_addr[4],ether_addr[5]);

--- a/src/ld.h
+++ b/src/ld.h
@@ -55,6 +55,9 @@ void warp_mouse_callback(int cp);
 // Logging stuff
 int logmsgf(int type, int level, const char *format, ...);
 
+// persistent storage for LAA address, per interface
+void make_locally_administered_address_for_interface(char *iface, unsigned char *ea);
+
 // Type numbers
 // Make sure these stay in sync with the array logtype_name in kernel.c
 // I can't initialize that here because gcc whines about it (sigh)


### PR DESCRIPTION
Support for (random) Locally Administered Addresses for ethernet interfaces to avoid collisions (and manual config) when running more than one lam process per network.
See https://www.why-did-it.fail/blog/old-04-mac-address-space/ and IEEE documents linked from there.